### PR TITLE
Add needed packages to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ support via poppler. In order to use this buildpack, you must install these pack
 - libglib2.0-0
 - libglib2.0-dev
 - libpoppler-glib8
+- libpoppler-glib-dev
+- libheif-dev
+- libfftw3-dev
+- libwebp-dev
 
 The easiest way to do this is using the heroku apt buildpack.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ support via poppler. In order to use this buildpack, you must install these pack
 - libglib2.0-0
 - libglib2.0-dev
 - libpoppler-glib8
+
+Additionally, if you are planning to use [sharp](https://github.com/lovell/sharp), you may also need the following packages:
 - libpoppler-glib-dev
 - libheif-dev
 - libfftw3-dev


### PR DESCRIPTION
Without these, I was getting errors about various `.pc` files being missing, see https://github.com/brandoncc/heroku-buildpack-vips/issues/5#issuecomment-980829786